### PR TITLE
Add gitleaks pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,6 +50,12 @@ repos:
       - id: codespell
         args: ["--write-changes"]
 
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.30.1
+    hooks:
+      - id: gitleaks
+        args: [--redact]
+
   - repo: local
     hooks:
       - id: mypy

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ We've bundled the following to get you up and running quickly:
 - **⚡️ Speedy Package Management:** Utilizes [uv](https://docs.astral.sh/uv/) for incredibly fast dependency resolution and package installation.
 - **✅ Strict Type-Checking:** Enforces code quality with [mypy](https://www.mypy-lang.org/) for robust static type analysis, catching errors early.
 - **✨ Blazing-Fast Linting & Formatting:** Leverages [ruff](https://docs.astral.sh/ruff/) for an all-in-one, high-performance linter, code formatter, and more.
-- **🚫 Automated Quality Checks:** Integrates [pre-commit](https://pre-commit.com/) hooks for `ruff`, `mypy`, `codespell`, `absolufy-imports`, `uv lock`, and other essential checks, ensuring code consistency before commits.
+- **🚫 Automated Quality Checks:** Integrates [pre-commit](https://pre-commit.com/) hooks for `ruff`, `mypy`, `codespell`, `gitleaks`, `absolufy-imports`, `uv lock`, and other essential checks, ensuring code consistency before commits.
 - **💻 VS Code Integration:** Includes [settings.json](.vscode/settings.json) and [launch.json](.vscode/launch.json) for streamlined development, with editor configurations and debug settings right out of the box.
 - **🤖 GitHub Actions Workflow:** Provides automated `pre-commit` checks, unit, and integration testing (on windows/linux/mac).
 - **🐳 Container Image Publishing:** Provides a ready-made `Dockerfile` and workflow that builds on every pull request


### PR DESCRIPTION
### Motivation
- Add secret-scanning to the pre-commit pipeline by integrating `gitleaks` so potential secrets are detected before commits.

### Description
- Updated `.pre-commit-config.yaml` to add the `gitleaks` repo at rev `v8.30.1` with the `gitleaks` hook using the `--redact` argument, and updated `README.md` to include `gitleaks` in the Automated Quality Checks list.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd2514eec88332b780a137b931229a)